### PR TITLE
Change destination and server for contact form

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,10 +16,10 @@ class Message
     mg_client = Mailgun::Client.new ENV['MAILGUN_API_KEY']
     info = {
       from: email,
-      to: 'alanvardy@gmail.com',
+      to: 'contact@mail.yegrb.com',
       subject: "Email from #{name} - YEGRB.com",
       text: "From: #{name}\nEmail: #{email}\n\n #{body}"
     }
-    mg_client.send_message 'mg.vardy.codes', info
+    mg_client.send_message 'mail.yegrb.com', info
   end
 end


### PR DESCRIPTION
Form now sends to a mailgun alias address (contact@mail.yegrb.com) so multiple recipients can be defined in the mailgun account config. Closes #729 probably.