### PR TITLE
use deep fetch before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: dokku-github-action
         uses: vitalyliber/dokku-github-action@v6.0
         env:


### PR DESCRIPTION
Should fix the failing CI deploy action.